### PR TITLE
fix: remove duplicate delete handler, use writable default DB path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,13 @@ RUN apk update && apk add git
 # copy every content from the local file to the image
 COPY . /app
 
+# Create the default data directory so the DB is writable without a volume mount.
+# Override the location at runtime with: -e DB_PATH=/your/path/db.sqlite3
+# Mount a volume here for persistence:  -v /host/data:/app/data
+RUN mkdir -p /app/data
+
+VOLUME ["/app/data"]
+
 # configure the container to run in an executed manner
 ENTRYPOINT [ "python" ]
 

--- a/raceready.py
+++ b/raceready.py
@@ -8,7 +8,7 @@ import os
 import sqlite3
 
 app = Flask(__name__)
-db_path = os.environ.get('DB_PATH', '/data/db.sqlite3')
+db_path = os.environ.get('DB_PATH', os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data', 'db.sqlite3'))
 socketio = SocketIO(app, cors_allowed_origins="*", logger=True, engineio_logger=True)
 log = structlog.get_logger()
 current_checklist_id = None  # Will be set on first access
@@ -250,19 +250,6 @@ def toggle_by_normalised_id():
     update_all_clients(data=updated_action)
     return jsonify({'success': True, 'data': updated_action}), 200
 
-@socketio.on('delete')
-def handle_delete(data):
-    log.info("Deleting", data=data)
-    con = get_db_connection()
-    cur = con.cursor()
-    if 'id' not in data:
-        emit('error', 'Missing id')
-        return
-    cur.execute('DELETE FROM actions WHERE id = ?', (data['id'],))
-    con.commit()
-    emit('deleted', data['id'], broadcast=True)
-    update_all_clients()
-
 @socketio.on('save')
 def handle_save(data):
     log.info("Saving", data=data)
@@ -417,13 +404,14 @@ def handle_message():
 @socketio.on('delete')
 def handle_delete(data):
     log.info("Deleting", data=data)
-    con = get_db_connection()
-    cur = con.cursor()
     if 'id' not in data:
         emit('error', 'Missing id')
         return
+    con = get_db_connection()
+    cur = con.cursor()
     cur.execute('DELETE FROM actions WHERE id = ?', (data['id'],))
     con.commit()
+    con.close()
     emit('deleted', {'id': data['id']}, broadcast=True)
 
 @socketio.on('reset_all')

--- a/raceready.py
+++ b/raceready.py
@@ -408,10 +408,12 @@ def handle_delete(data):
         emit('error', 'Missing id')
         return
     con = get_db_connection()
-    cur = con.cursor()
-    cur.execute('DELETE FROM actions WHERE id = ?', (data['id'],))
-    con.commit()
-    con.close()
+    try:
+        cur = con.cursor()
+        cur.execute('DELETE FROM actions WHERE id = ?', (data['id'],))
+        con.commit()
+    finally:
+        con.close()
     emit('deleted', {'id': data['id']}, broadcast=True)
 
 @socketio.on('reset_all')


### PR DESCRIPTION
- Remove first (broken) handle_delete: emitted raw integer ID instead of {id:...} object, called update_all_clients() unnecessarily, and leaked the DB connection
- Surviving handler now closes connection and moves guard clause before opening the connection
- Change default DB_PATH from /data/db.sqlite3 to a path relative to the script itself (../data/db.sqlite3), which is always user-writable
- Dockerfile: pre-create /app/data with RUN mkdir and add VOLUME declaration so the DB survives container restarts without needing a manual mount

AI generated