### PR TITLE
feat: add test suite, badges, and CI test step

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.8'
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Run tests

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -12,7 +12,20 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: pytest tests/ -v
+
   semver:
+    needs: test
     runs-on: ubuntu-latest
     outputs:
       fullSemVer: ${{ steps.gitversion.outputs.fullSemVer }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: pytest tests/ -v

--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ cython_debug/
 #.idea/
 
 data/db.sqlite3
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Docker Build](https://github.com/Pingue/raceready/actions/workflows/docker_build.yml/badge.svg)](https://github.com/Pingue/raceready/actions/workflows/docker_build.yml)
 [![Docker Pulls](https://img.shields.io/docker/pulls/pingue/raceready)](https://hub.docker.com/r/pingue/raceready)
-[![Python 3.7+](https://img.shields.io/badge/python-3.7%2B-blue?logo=python&logoColor=white)](https://www.python.org)
+[![Python 3.8+](https://img.shields.io/badge/python-3.8%2B-blue?logo=python&logoColor=white)](https://www.python.org)
 [![License](https://img.shields.io/github/license/Pingue/raceready)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-assisted-blueviolet?logo=anthropic&logoColor=white)](https://claude.ai/claude-code)
 
@@ -32,7 +32,7 @@ RaceReady is a web-based collaborative checklist application designed for commun
 ## Quick Start
 
 ### Prerequisites
-- Python 3.7+
+- Python 3.8+
 - SQLite3
 - Modern web browser
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Race Ready
 
+[![Docker Build](https://github.com/Pingue/raceready/actions/workflows/docker_build.yml/badge.svg)](https://github.com/Pingue/raceready/actions/workflows/docker_build.yml)
+[![Docker Pulls](https://img.shields.io/docker/pulls/pingue/raceready)](https://hub.docker.com/r/pingue/raceready)
+[![Python 3.7+](https://img.shields.io/badge/python-3.7%2B-blue?logo=python&logoColor=white)](https://www.python.org)
+[![License](https://img.shields.io/github/license/Pingue/raceready)](LICENSE)
+[![Claude Code](https://img.shields.io/badge/Claude%20Code-assisted-blueviolet?logo=anthropic&logoColor=white)](https://claude.ai/claude-code)
+
 **Collaborative Checklist System for Racing Events**
 
 RaceReady is a web-based collaborative checklist application designed for communicating between teams on large events. It was developed for the GT World Series eSports events, however is flexible enough to be used for various types of events. It provides real-time synchronization of checklist items across multiple devices and integrates seamlessly with Companion for streamlined workflow management.
@@ -60,13 +66,13 @@ RaceReady is a web-based collaborative checklist application designed for commun
 ### Docker Deployment from dockerhub
 ```bash
 docker pull pingue/raceready:latest
-docker run -p 5000:5000 -v ./data:/data pingue/raceready:latest
+docker run -p 5000:5000 -v ./data:/app/data pingue/raceready:latest
 ```
 
 ## Configuration
 
 ### Environment Variables
-- `DB_PATH`: Path to SQLite database file (default: `/data/db.sqlite3`)
+- `DB_PATH`: Path to SQLite database file (default: `./data/db.sqlite3` relative to the script)
 
 ### Database Setup
 The application automatically creates the necessary database tables on first run:
@@ -158,7 +164,7 @@ echo .dump | sudo sqlite3 data/db.sqlite3 | sudo sqlite3 data/db2.sqlite3 && sud
 ### Docker Deployment
 ```bash
 docker build -t raceready .
-docker run -p 5000:5000 -v ./data:/data raceready
+docker run -p 5000:5000 -v ./data:/app/data raceready
 ```
 
 ### Production Considerations

--- a/raceready.py
+++ b/raceready.py
@@ -835,11 +835,12 @@ def handle_move_checklist_down(data):
         log.error("Error moving checklist down", error=str(e))
         emit('error', 'Internal server error')
 
-# Ensure DB file and schema exist on startup
-startup_con = get_db_connection()
-startup_con.close()
-
 if __name__ == "__main__":
+    # Ensure DB file and schema exist before the server starts accepting
+    # requests. Not needed when running under a WSGI server (gunicorn etc.)
+    # because get_db_connection() initialises the schema on the first request.
+    startup_con = get_db_connection()
+    startup_con.close()
     port = int(os.environ.get('PORT', 5000))
     print("app running")
     socketio.run(app, host="0.0.0.0", port=port)

--- a/raceready.py
+++ b/raceready.py
@@ -8,7 +8,12 @@ import os
 import sqlite3
 
 app = Flask(__name__)
-db_path = os.environ.get('DB_PATH', os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data', 'db.sqlite3'))
+
+def _default_db_path() -> str:
+    """Return the default DB path: <script_dir>/data/db.sqlite3."""
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data', 'db.sqlite3')
+
+db_path = os.environ.get('DB_PATH', _default_db_path())
 socketio = SocketIO(app, cors_allowed_origins="*", logger=True, engineio_logger=True)
 log = structlog.get_logger()
 current_checklist_id = None  # Will be set on first access

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 Flask==2.3.2
+Werkzeug==2.3.7
 flask-socketio==5.1.1
 requests==2.26.0
 structlog==21.2.0
+pytest==7.4.0

--- a/tests/test_raceready.py
+++ b/tests/test_raceready.py
@@ -86,14 +86,13 @@ class TestDbMigration:
         assert "notes" in columns
 
     def test_default_db_path_is_not_slash_data(self):
-        """The default DB path must not be the old read-only /data location."""
-        # Re-derive the default the same way the module does, without relying
-        # on the monkeypatched value set by patch_db.
+        """_default_db_path() must return a script-relative path, not /data/db.sqlite3."""
         import os
-        script_dir = os.path.dirname(os.path.abspath(raceready.__file__))
-        default = os.path.join(script_dir, "data", "db.sqlite3")
-        assert not default.startswith("/data/db.sqlite3")
-        assert "raceready" in default or "data" in default
+        default = raceready._default_db_path()
+        assert default != '/data/db.sqlite3'
+        assert not default.startswith('/data/')
+        assert default.endswith(os.path.join('data', 'db.sqlite3'))
+        assert os.path.isabs(default)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_raceready.py
+++ b/tests/test_raceready.py
@@ -1,0 +1,309 @@
+"""
+Tests for raceready.py
+
+Uses Flask's built-in test client for HTTP endpoints and flask-socketio's
+test_client() for WebSocket events. Each test gets a fresh temporary SQLite
+database via the `patch_db` fixture so tests are fully isolated.
+"""
+
+import pytest
+import sqlite3
+import raceready
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def patch_db(tmp_path, monkeypatch):
+    """Redirect all DB operations to a fresh temp DB for every test."""
+    db_file = str(tmp_path / "test.sqlite3")
+    monkeypatch.setattr(raceready, "db_path", db_file)
+    monkeypatch.setattr(raceready, "current_checklist_id", None)
+    # Initialise schema in the temp DB
+    con = raceready.get_db_connection()
+    con.close()
+
+
+@pytest.fixture
+def http(patch_db):
+    raceready.app.config["TESTING"] = True
+    with raceready.app.test_client() as client:
+        yield client
+
+
+@pytest.fixture
+def ws(patch_db):
+    raceready.app.config["TESTING"] = True
+    sc = raceready.socketio.test_client(raceready.app)
+    sc.get_received()  # discard the initial 'connected' event
+    yield sc
+    sc.disconnect()
+
+
+def _seed_action(text="Check Audio", status=0, notes=""):
+    """Insert an action directly into the test DB and return its id."""
+    con = raceready.get_db_connection()
+    cid = raceready.get_current_checklist_id()
+    con.execute(
+        'INSERT INTO actions (text, "order", status, checklist_id, notes) VALUES (?, 1, ?, ?, ?)',
+        (text, status, cid, notes),
+    )
+    con.commit()
+    cur = con.execute("SELECT last_insert_rowid()")
+    row_id = cur.fetchone()[0]
+    con.close()
+    return row_id
+
+
+# ---------------------------------------------------------------------------
+# DB Migration
+# ---------------------------------------------------------------------------
+
+class TestDbMigration:
+    def test_notes_column_added_to_existing_db(self, tmp_path, monkeypatch):
+        """A DB that predates the notes column should have it added automatically."""
+        db_file = str(tmp_path / "old.sqlite3")
+
+        # Build a DB that looks like it was created before the notes column existed
+        con = sqlite3.connect(db_file)
+        con.execute("CREATE TABLE checklists (id INTEGER PRIMARY KEY, name TEXT, order_pos INTEGER DEFAULT 0)")
+        con.execute("INSERT INTO checklists (name, order_pos) VALUES ('Default', 1)")
+        con.execute('CREATE TABLE actions (id INTEGER PRIMARY KEY, text TEXT, "order" INT, status INT, checklist_id INT)')
+        con.commit()
+        con.close()
+
+        monkeypatch.setattr(raceready, "db_path", db_file)
+        monkeypatch.setattr(raceready, "current_checklist_id", None)
+
+        con = raceready.get_db_connection()
+        cur = con.cursor()
+        cur.execute("PRAGMA table_info(actions)")
+        columns = [col[1] for col in cur.fetchall()]
+        con.close()
+
+        assert "notes" in columns
+
+    def test_default_db_path_is_not_slash_data(self):
+        """The default DB path must not be the old read-only /data location."""
+        # Re-derive the default the same way the module does, without relying
+        # on the monkeypatched value set by patch_db.
+        import os
+        script_dir = os.path.dirname(os.path.abspath(raceready.__file__))
+        default = os.path.join(script_dir, "data", "db.sqlite3")
+        assert not default.startswith("/data/db.sqlite3")
+        assert "raceready" in default or "data" in default
+
+
+# ---------------------------------------------------------------------------
+# HTTP endpoints
+# ---------------------------------------------------------------------------
+
+class TestHttpEndpoints:
+    def test_home_ok(self, http):
+        assert http.get("/").status_code == 200
+
+    def test_admin_ok(self, http):
+        assert http.get("/admin").status_code == 200
+
+    def test_toggle_by_title_missing_body(self, http):
+        assert http.post("/toggle_by_title", json={}).status_code == 400
+
+    def test_toggle_by_title_not_found(self, http):
+        assert http.post("/toggle_by_title", json={"title": "Ghost Item"}).status_code == 404
+
+    def test_toggle_by_title_toggles_status(self, http):
+        _seed_action("Check Audio", status=0)
+        resp = http.post("/toggle_by_title", json={"title": "Check Audio"})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["data"]["status"] == 1  # 0 → 1
+
+    def test_toggle_by_title_toggles_back(self, http):
+        _seed_action("Check Audio", status=1)
+        resp = http.post("/toggle_by_title", json={"title": "Check Audio"})
+        assert resp.get_json()["data"]["status"] == 0  # 1 → 0
+
+    def test_action_title_missing_id(self, http):
+        assert http.get("/action_title").status_code == 400
+
+    def test_action_title_invalid_id(self, http):
+        assert http.get("/action_title?id=abc").status_code == 400
+
+    def test_action_title_not_found(self, http):
+        assert http.get("/action_title?id=9999").status_code == 404
+
+    def test_action_title_returns_text(self, http):
+        _seed_action("Check Cameras")
+        con = raceready.get_db_connection()
+        cur = con.execute("SELECT id FROM actions WHERE text='Check Cameras'")
+        action_id = cur.fetchone()[0]
+        con.close()
+
+        resp = http.get(f"/action_title?id={action_id}")
+        assert resp.status_code == 200
+        assert resp.get_json()["text"] == "Check Cameras"
+
+    def test_create_checklist(self, http):
+        resp = http.post("/create_checklist", json={"name": "Pre-show"})
+        assert resp.status_code == 201
+        assert resp.get_json()["name"] == "Pre-show"
+
+    def test_create_checklist_missing_name(self, http):
+        assert http.post("/create_checklist", json={}).status_code == 400
+
+    def test_delete_checklist(self, http):
+        resp = http.post("/create_checklist", json={"name": "Temp"})
+        cid = resp.get_json()["id"]
+
+        http.post("/delete_checklist", json={"id": cid})
+
+        ids = [c["id"] for c in http.get("/checklists").get_json()]
+        assert cid not in ids
+
+    def test_rename_checklist(self, http):
+        resp = http.post("/create_checklist", json={"name": "Old Name"})
+        cid = resp.get_json()["id"]
+
+        http.post("/rename_checklist", json={"id": cid, "name": "New Name"})
+
+        checklists = http.get("/checklists").get_json()
+        names = {c["id"]: c["name"] for c in checklists}
+        assert names[cid] == "New Name"
+
+
+# ---------------------------------------------------------------------------
+# WebSocket events
+# ---------------------------------------------------------------------------
+
+class TestWebSocketEvents:
+    def test_add_creates_item_in_db(self, ws):
+        ws.emit("add", {"text": "Check Stream"})
+        ws.get_received()
+
+        con = raceready.get_db_connection()
+        cur = con.execute("SELECT text FROM actions WHERE text='Check Stream'")
+        row = cur.fetchone()
+        con.close()
+        assert row is not None
+
+    def test_add_item_appears_in_db(self, ws):
+        # Separate from test_add_creates_item_in_db — verifies order is assigned
+        ws.emit("add", {"text": "Check Comms"})
+        ws.get_received()
+
+        con = raceready.get_db_connection()
+        cur = con.execute('SELECT text, "order" FROM actions WHERE text="Check Comms"')
+        row = cur.fetchone()
+        con.close()
+        assert row is not None
+        assert row[1] is not None  # order was set
+
+    def test_delete_removes_item(self, ws):
+        # broadcast=True in the handler excludes the sender, so we verify
+        # the deletion via DB state rather than received events.
+        action_id = _seed_action("Check Graphics")
+        ws.emit("delete", {"id": action_id})
+        ws.get_received()
+
+        con = raceready.get_db_connection()
+        cur = con.execute("SELECT id FROM actions WHERE id=?", (action_id,))
+        assert cur.fetchone() is None
+        con.close()
+
+    def test_delete_missing_id_leaves_db_unchanged(self, ws):
+        # Emitting delete without an id should be a no-op on the DB.
+        action_id = _seed_action("Check Graphics")
+        ws.emit("delete", {})
+        ws.get_received()
+
+        con = raceready.get_db_connection()
+        cur = con.execute("SELECT id FROM actions WHERE id=?", (action_id,))
+        assert cur.fetchone() is not None  # still there
+        con.close()
+
+    def test_save_persists_notes(self, ws):
+        action_id = _seed_action("Check Replays", notes="")
+        ws.emit("save", {"id": action_id, "text": "Check Replays", "notes": "HD only"})
+        ws.get_received()
+
+        con = raceready.get_db_connection()
+        cur = con.execute("SELECT notes FROM actions WHERE id=?", (action_id,))
+        assert cur.fetchone()[0] == "HD only"
+        con.close()
+
+    def test_save_persists_text(self, ws):
+        action_id = _seed_action("Old Text")
+        ws.emit("save", {"id": action_id, "text": "New Text"})
+        ws.get_received()
+
+        con = raceready.get_db_connection()
+        cur = con.execute("SELECT text FROM actions WHERE id=?", (action_id,))
+        assert cur.fetchone()[0] == "New Text"
+        con.close()
+
+    def test_toggle_state_flips_status(self, ws):
+        action_id = _seed_action("Check Audio", status=0)
+        ws.emit("toggle_state", {"id": action_id})
+        ws.get_received()
+
+        con = raceready.get_db_connection()
+        cur = con.execute("SELECT status FROM actions WHERE id=?", (action_id,))
+        assert cur.fetchone()[0] == 1
+        con.close()
+
+    def test_toggle_state_flips_back(self, ws):
+        action_id = _seed_action("Check Audio", status=1)
+        ws.emit("toggle_state", {"id": action_id})
+        ws.get_received()
+
+        con = raceready.get_db_connection()
+        cur = con.execute("SELECT status FROM actions WHERE id=?", (action_id,))
+        assert cur.fetchone()[0] == 0
+        con.close()
+
+    def test_reset_all_clears_statuses(self, ws):
+        _seed_action("Item A", status=1)
+        _seed_action("Item B", status=1)
+        ws.emit("reset_all")
+        ws.get_received()
+
+        con = raceready.get_db_connection()
+        cur = con.execute("SELECT SUM(status) FROM actions")
+        assert cur.fetchone()[0] == 0
+        con.close()
+
+    def test_up_reorders_items(self, ws):
+        con = raceready.get_db_connection()
+        cid = raceready.get_current_checklist_id()
+        con.execute('INSERT INTO actions (id, text, "order", status, checklist_id, notes) VALUES (1, "First", 1, 0, ?, "")', (cid,))
+        con.execute('INSERT INTO actions (id, text, "order", status, checklist_id, notes) VALUES (2, "Second", 2, 0, ?, "")', (cid,))
+        con.commit()
+        con.close()
+
+        ws.emit("up", {"id": 2})
+        ws.get_received()
+
+        con = raceready.get_db_connection()
+        cur = con.execute('SELECT id FROM actions ORDER BY "order"')
+        order = [r[0] for r in cur.fetchall()]
+        con.close()
+        assert order == [2, 1]
+
+    def test_next_and_previous_checklist(self, ws):
+        # Create a second checklist
+        con = raceready.get_db_connection()
+        con.execute("INSERT INTO checklists (name, order_pos) VALUES ('Second', 2)")
+        con.commit()
+        second_id = con.execute("SELECT id FROM checklists WHERE name='Second'").fetchone()[0]
+        con.close()
+
+        ws.emit("next_checklist")
+        ws.get_received()
+        assert raceready.current_checklist_id == second_id
+
+        ws.emit("previous_checklist")
+        ws.get_received()
+        assert raceready.current_checklist_id != second_id


### PR DESCRIPTION
- 27 pytest tests covering DB migration, all HTTP endpoints, and WebSocket events (add, delete, save, toggle, reset, reorder, checklist switching); each test runs against an isolated temp DB
- Pin Werkzeug==2.3.7 for Flask 2.3.2 compatibility
- Add pytest==7.4.0 to requirements.txt
- Add 'test' job to docker_build.yml workflow; Docker build now requires tests to pass first
- Add shields.io badges to README (CI, Docker Hub, Python, License, Claude Code)
- Fix stale Docker volume mount paths in README (data:/data → data:/app/data) and update DB_PATH default description